### PR TITLE
feat: added rejection button for admins

### DIFF
--- a/src/components/AdminDashboard/RejectPendingApplication/index.tsx
+++ b/src/components/AdminDashboard/RejectPendingApplication/index.tsx
@@ -1,36 +1,62 @@
 "use client";
 
+import { zodResolver } from "@hookform/resolvers/zod";
 import { Clear as ClearIcon } from "@mui/icons-material";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
-import FormControl from "@mui/material/FormControl";
 import Modal from "@mui/material/Modal";
-import TextField from "@mui/material/TextField";
+import Snackbar from "@mui/material/Snackbar";
 import Typography from "@mui/material/Typography";
 import React, { useState } from "react";
-import { Controller, useForm } from "react-hook-form";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+
+import ControlledTextInput from "@/components/forms/ControlledTextInput";
+
+const rejectionReasonSchema = z.object({
+  rejectionReason: z.string().min(1, { message: "Reason is required" }),
+});
+
+type RejectButtonFormValues = z.infer<typeof rejectionReasonSchema>;
 
 export default function RejectButton({
-  height = 40,
-  width = 100,
+  height,
+  width,
 }: {
   height?: number;
   width?: number;
 }) {
   const [open, setOpen] = useState(false);
-  const { control, handleSubmit } = useForm<{ rejectionReason: string }>();
+  const [snackbarOpen, setSnackbarOpen] = useState(false);
+
+  const {
+    control,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<RejectButtonFormValues>({
+    resolver: zodResolver(rejectionReasonSchema),
+    defaultValues: { rejectionReason: "" },
+  });
 
   const handleOpen = () => setOpen(true);
   const handleClose = () => setOpen(false);
 
-  const onSubmit = (data: { rejectionReason: string }) => {
-    // add submission logic here later.
+  const onSubmit = (data: RejectButtonFormValues) => {
+    // Add submission logic here later
+    // eslint-disable-next-line no-console
     console.log(data.rejectionReason);
+    setSnackbarOpen(true);
     handleClose();
   };
 
   return (
     <>
+      <Snackbar
+        open={snackbarOpen}
+        autoHideDuration={6000}
+        onClose={() => setSnackbarOpen(false)}
+        message="Rejection reason submitted"
+      />
       <Button
         variant="contained"
         color="error"
@@ -41,45 +67,38 @@ export default function RejectButton({
         Reject
       </Button>
       <Modal open={open} onClose={handleClose}>
-        <Box
-          sx={{
-            position: "absolute" as const,
-            top: "50%",
-            left: "50%",
-            transform: "translate(-50%, -50%)",
-            width: 400,
-            bgcolor: "background.paper",
-            borderRadius: 4,
-            p: 4,
-          }}
-        >
-          <Typography variant="h6" component="h2">
-            Rejection Reason
-          </Typography>
-          <form onSubmit={handleSubmit(onSubmit)}>
-            <FormControl fullWidth margin="normal">
-              <Controller
-                name="rejectionReason"
-                control={control}
-                defaultValue=""
-                render={({ field }) => (
-                  <TextField
-                    {...field}
-                    label="Rejection Reason"
-                    multiline
-                    rows={4}
-                    variant="outlined"
-                    fullWidth
-                    margin="normal"
-                  />
-                )}
-              />
-            </FormControl>
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <Box
+            sx={{
+              position: "absolute" as const,
+              top: "50%",
+              left: "50%",
+              transform: "translate(-50%, -50%)",
+              width: "min(90vw, 700px)",
+              display: "grid",
+              gap: 1.5,
+              gridTemplateColumns: "1fr",
+              boxShadow: 2,
+              borderRadius: 2,
+              p: 3,
+              bgcolor: "background.paper",
+            }}
+          >
+            <Typography variant="h4">Rejection Reason</Typography>
+            <ControlledTextInput
+              control={control}
+              name="rejectionReason"
+              label="Rejection Reason"
+              multiline
+              rows={4}
+              variant="outlined"
+              error={errors.rejectionReason}
+            />
             <Button type="submit" variant="contained" color="error">
               Reject
             </Button>
-          </form>
-        </Box>
+          </Box>
+        </form>
       </Modal>
     </>
   );

--- a/src/components/AdminDashboard/RejectPendingApplication/index.tsx
+++ b/src/components/AdminDashboard/RejectPendingApplication/index.tsx
@@ -19,13 +19,15 @@ const rejectionReasonSchema = z.object({
 
 type RejectButtonFormValues = z.infer<typeof rejectionReasonSchema>;
 
-export default function RejectButton({
-  height,
-  width,
-}: {
+type RejectPendingApplicationProps = {
   height?: number;
   width?: number;
-}) {
+};
+
+export default function RejectPendingApplication({
+  height,
+  width,
+}: RejectPendingApplicationProps) {
   const [open, setOpen] = useState(false);
   const [snackbarOpen, setSnackbarOpen] = useState(false);
 
@@ -33,6 +35,7 @@ export default function RejectButton({
     control,
     handleSubmit,
     formState: { errors },
+    reset,
   } = useForm<RejectButtonFormValues>({
     resolver: zodResolver(rejectionReasonSchema),
     defaultValues: { rejectionReason: "" },
@@ -45,6 +48,7 @@ export default function RejectButton({
     // Add submission logic here later
     // eslint-disable-next-line no-console
     console.log(data.rejectionReason);
+    reset({ rejectionReason: "" });
     setSnackbarOpen(true);
     handleClose();
   };
@@ -53,9 +57,9 @@ export default function RejectButton({
     <>
       <Snackbar
         open={snackbarOpen}
-        autoHideDuration={6000}
+        autoHideDuration={3000}
         onClose={() => setSnackbarOpen(false)}
-        message="Rejection reason submitted"
+        message="Application successfully rejected"
       />
       <Button
         variant="contained"

--- a/src/components/AdminDashboard/RejectPendingApplication/index.tsx
+++ b/src/components/AdminDashboard/RejectPendingApplication/index.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { Clear as ClearIcon } from "@mui/icons-material";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import FormControl from "@mui/material/FormControl";
+import Modal from "@mui/material/Modal";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
+import React, { useState } from "react";
+import { Controller, useForm } from "react-hook-form";
+
+export default function RejectButton({
+  height = 40,
+  width = 100,
+}: {
+  height?: number;
+  width?: number;
+}) {
+  const [open, setOpen] = useState(false);
+  const { control, handleSubmit } = useForm<{ rejectionReason: string }>();
+
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => setOpen(false);
+
+  const onSubmit = (data: { rejectionReason: string }) => {
+    // add submission logic here later.
+    console.log(data.rejectionReason);
+    handleClose();
+  };
+
+  return (
+    <>
+      <Button
+        variant="contained"
+        color="error"
+        startIcon={<ClearIcon />}
+        onClick={handleOpen}
+        style={{ height, width }}
+      >
+        Reject
+      </Button>
+      <Modal open={open} onClose={handleClose}>
+        <Box
+          sx={{
+            position: "absolute" as const,
+            top: "50%",
+            left: "50%",
+            transform: "translate(-50%, -50%)",
+            width: 400,
+            bgcolor: "background.paper",
+            borderRadius: 4,
+            p: 4,
+          }}
+        >
+          <Typography variant="h6" component="h2">
+            Rejection Reason
+          </Typography>
+          <form onSubmit={handleSubmit(onSubmit)}>
+            <FormControl fullWidth margin="normal">
+              <Controller
+                name="rejectionReason"
+                control={control}
+                defaultValue=""
+                render={({ field }) => (
+                  <TextField
+                    {...field}
+                    label="Rejection Reason"
+                    multiline
+                    rows={4}
+                    variant="outlined"
+                    fullWidth
+                    margin="normal"
+                  />
+                )}
+              />
+            </FormControl>
+            <Button type="submit" variant="contained" color="error">
+              Reject
+            </Button>
+          </form>
+        </Box>
+      </Modal>
+    </>
+  );
+}


### PR DESCRIPTION
# Description
Added a rejection button for admins at ```src/components/AdminDashboard/RejectPendingApplication/index.tsx```
The button can take a height and width parameter but if not they default to 40 x 100. I tried to only use MUI but MUI Form Control doesn't have a submit feature so I used a regular react form.


I was testing with this code in ```src/app/dashboard/admin/page.tsx```:
```jsx
import { Box } from "@mui/material";
import { redirect } from "next/navigation";

import RejectButton from "@/components/AdminDashboard/RejectPendingApplication";
import getUserSession from "@/utils/getUserSession";

export default async function AdminDashboardPage() {
  const session = await getUserSession();

  if (!session || session.user.role !== "admin") {
    return redirect("/dashboard");
  }

  return (
    <Box
      sx={{
        height: "100vh",
        width: "100vw",
        display: "flex",
        justifyContent: "center",
        alignItems: "center",
      }}
    >
      <p>Admin dashboard page</p>
      <RejectButton />
    </Box>
  );
}

```
## Relevant Issues
Closes #37 Reject Button and Modal that Contains the Form
