### PR TITLE
feat: create settings page

### DIFF
--- a/src/app/settings/admin/page.tsx
+++ b/src/app/settings/admin/page.tsx
@@ -1,7 +1,7 @@
 import { Box } from "@mui/material";
 import { redirect } from "next/navigation";
 
-import SignOutButton from "@/components/Settings/SignOutButton";
+import AdminSettings from "@/components/Settings/AdminSettings";
 import getUserSession from "@/utils/getUserSession";
 
 export default async function AdminSettingsPage() {
@@ -10,6 +10,8 @@ export default async function AdminSettingsPage() {
   if (!session || session.user.role !== "admin") {
     redirect("/");
   }
+
+  const { user } = session;
 
   return (
     <Box
@@ -20,10 +22,10 @@ export default async function AdminSettingsPage() {
         justifyContent: "center",
         alignItems: "center",
         flexDirection: "column",
+        gap: 2,
       }}
     >
-      <p>Admin settings page</p>
-      <SignOutButton />
+      <AdminSettings user={user} />
     </Box>
   );
 }

--- a/src/app/settings/client/page.tsx
+++ b/src/app/settings/client/page.tsx
@@ -1,15 +1,17 @@
 import { Box } from "@mui/material";
 import { redirect } from "next/navigation";
 
-import SignOutButton from "@/components/Settings/SignOutButton";
+import ClientSettings from "@/components/Settings/ClientSettings";
 import getUserSession from "@/utils/getUserSession";
 
-export default async function ClientSettingsPage() {
+export default async function AdminSettingsPage() {
   const session = await getUserSession();
 
   if (!session || session.user.role !== "client") {
     redirect("/");
   }
+
+  const { user } = session;
 
   return (
     <Box
@@ -20,10 +22,10 @@ export default async function ClientSettingsPage() {
         justifyContent: "center",
         alignItems: "center",
         flexDirection: "column",
+        gap: 2,
       }}
     >
-      <p>Client settings page</p>
-      <SignOutButton />
+      <ClientSettings user={user} />
     </Box>
   );
 }

--- a/src/components/Settings/AdminSettings.tsx
+++ b/src/components/Settings/AdminSettings.tsx
@@ -1,0 +1,37 @@
+import { Box, Button, Typography } from "@mui/material";
+import Link from "next/link";
+
+import SignOutButton from "@/components/Settings/SignOutButton";
+
+type AdminSettingsProps = {
+  user: {
+    firstName: string;
+    lastName: string;
+    email: string;
+  };
+};
+
+export default function AdminSettings({ user }: AdminSettingsProps) {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: 2,
+      }}
+    >
+      <Typography variant="h4">Admin Settings</Typography>
+      <Typography variant="body1">
+        Name: {user.firstName} {user.lastName}
+      </Typography>
+      <Typography variant="body1">Email: {user.email}</Typography>
+      <Link href="/change-password" passHref>
+        <Button variant="contained" color="primary">
+          Reset Password
+        </Button>
+      </Link>
+      <SignOutButton />
+    </Box>
+  );
+}

--- a/src/components/Settings/ClientSettings.tsx
+++ b/src/components/Settings/ClientSettings.tsx
@@ -1,0 +1,37 @@
+import { Box, Button, Typography } from "@mui/material";
+import Link from "next/link";
+
+import SignOutButton from "@/components/Settings/SignOutButton";
+
+type ClientSettingsProps = {
+  user: {
+    firstName: string;
+    lastName: string;
+    email: string;
+  };
+};
+
+export default function ClientSettings({ user }: ClientSettingsProps) {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: 2,
+      }}
+    >
+      <Typography variant="h4">Client Settings</Typography>
+      <Typography variant="body1">
+        Name: {user.firstName} {user.lastName}
+      </Typography>
+      <Typography variant="body1">Email: {user.email}</Typography>
+      <Link href="/change-password" passHref>
+        <Button variant="contained" color="primary">
+          Reset Password
+        </Button>
+      </Link>
+      <SignOutButton />
+    </Box>
+  );
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,3 +1,3 @@
 export { default } from "next-auth/middleware";
 
-export const config = { matcher: ["/dashboard", "/dashboard/:path*", "/settings/:path*"] };
+export const config = { matcher: ["/dashboard", "/dashboard/:path*", "/settings" ,"/settings/:path*"] };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,3 +1,5 @@
 export { default } from "next-auth/middleware";
 
-export const config = { matcher: ["/dashboard", "/dashboard/:path*", "/settings" ,"/settings/:path*"] };
+export const config = {
+  matcher: ["/dashboard", "/dashboard/:path*", "/settings", "/settings/:path*"],
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,3 +1,3 @@
 export { default } from "next-auth/middleware";
 
-export const config = { matcher: ["/dashboard", "/dashboard/:path*"] };
+export const config = { matcher: ["/dashboard", "/dashboard/:path*", "/settings/:path*"] };


### PR DESCRIPTION
# Description
created the admin and client settings components, displays the user's name, email, a change password button and sign out button. added these components to the respective admin and client settings pages. updated middleware to cover settings pages
## Relevant Issues
NA
## How to Test
confirm admin page is only accessible by admins and vice versa, and non-logged in users can't see either