### PR TITLE
feat: start rigs without cigs

### DIFF
--- a/src/app/dashboard/client/rigs-without-cigs/page.tsx
+++ b/src/app/dashboard/client/rigs-without-cigs/page.tsx
@@ -48,6 +48,11 @@ export default async function RigsWithoutCigsPage(): Promise<ReactNode> {
   if (!enrolledInRigsWithoutCigsProgram) {
     redirect("/dashboard/client");
   }
+
+  const rigsWithoutCigsEnrollment = user.programEnrollments.find(
+    (enrollment) => enrollment.program === "Rigs Without Cigs",
+  );
+
   return (
     <Box
       sx={{
@@ -59,7 +64,10 @@ export default async function RigsWithoutCigsPage(): Promise<ReactNode> {
         padding: 1,
       }}
     >
-      <RigsWithoutCigs user={user} />
+      <RigsWithoutCigs
+        user={user}
+        programEnrollment={rigsWithoutCigsEnrollment!}
+      />
     </Box>
   );
 }

--- a/src/app/dashboard/client/rigs-without-cigs/page.tsx
+++ b/src/app/dashboard/client/rigs-without-cigs/page.tsx
@@ -2,6 +2,7 @@ import { Box, Typography } from "@mui/material";
 import { redirect } from "next/navigation";
 import { ReactNode } from "react";
 
+import RigsWithoutCigs from "@/components/ClientDashboard/RigsWithoutCigs";
 import { getUserByEmail } from "@/server/api/users/queries";
 import getUserSession from "@/utils/getUserSession";
 import isUserEnrolledInProgram from "@/utils/isEnrolledInProgram";
@@ -49,14 +50,15 @@ export default async function RigsWithoutCigsPage(): Promise<ReactNode> {
   return (
     <Box
       sx={{
-        height: "100vh",
-        width: "100vw",
         display: "flex",
+        flexDirection: "column",
         justifyContent: "center",
         alignItems: "center",
+        marginTop: "100px",
+        padding: 1,
       }}
     >
-      <Typography>Rigs Without Cigs Page</Typography>
+      <RigsWithoutCigs user={user} />
     </Box>
   );
 }

--- a/src/app/dashboard/client/rigs-without-cigs/page.tsx
+++ b/src/app/dashboard/client/rigs-without-cigs/page.tsx
@@ -16,6 +16,7 @@ export default async function RigsWithoutCigsPage(): Promise<ReactNode> {
 
   const [user, error] = await getUserByEmail(session.user.email, {
     populateProgramEnrollments: true,
+    populateEnrollmentForm: true,
   });
 
   if (error !== null) {

--- a/src/components/ClientDashboard/RigsWithoutCigs/FagerstromTest/CigaretteFagerstromTest.tsx
+++ b/src/components/ClientDashboard/RigsWithoutCigs/FagerstromTest/CigaretteFagerstromTest.tsx
@@ -24,12 +24,12 @@ export default function CigaretteFagerstromTest(): ReactNode {
   } = useForm<CigaretteFagerstromTestForm>({
     resolver: zodResolver(cigaretteFagerstromTestFormValidator),
     defaultValues: {
-      firstCigarette: 0,
-      refrainInForbiddenAreas: 0,
-      whichGiveUpHate: 0,
-      cigarettesPerDay: 0,
-      frequentlyInMorning: 0,
-      smokeWhenSickInBed: 0,
+      firstCigarette: -1,
+      refrainInForbiddenAreas: -1,
+      whichGiveUpHate: -1,
+      cigarettesPerDay: -1,
+      frequentlyInMorning: -1,
+      smokeWhenSickInBed: -1,
     },
   });
 
@@ -131,7 +131,7 @@ export default function CigaretteFagerstromTest(): ReactNode {
                 <FormControlLabel
                   value="1"
                   control={<Radio />}
-                  label="The first one in the morning morning"
+                  label="The first one in the morning"
                 />
                 <FormControlLabel
                   value="0"

--- a/src/components/ClientDashboard/RigsWithoutCigs/FagerstromTest/CigaretteFagerstromTest.tsx
+++ b/src/components/ClientDashboard/RigsWithoutCigs/FagerstromTest/CigaretteFagerstromTest.tsx
@@ -1,0 +1,6 @@
+import { Typography } from "@mui/material";
+import { ReactNode } from "react";
+
+export default function CigaretteFagerstromTest(): ReactNode {
+  return <Typography>Cigarette Fagerstrom Test</Typography>;
+}

--- a/src/components/ClientDashboard/RigsWithoutCigs/FagerstromTest/CigaretteFagerstromTest.tsx
+++ b/src/components/ClientDashboard/RigsWithoutCigs/FagerstromTest/CigaretteFagerstromTest.tsx
@@ -1,4 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod";
+import LoadingButton from "@mui/lab/LoadingButton";
 import {
   Box,
   FormControl,
@@ -7,6 +8,7 @@ import {
   FormLabel,
   Radio,
   RadioGroup,
+  Typography,
 } from "@mui/material";
 import { ReactNode } from "react";
 import { Controller, useForm } from "react-hook-form";
@@ -229,6 +231,19 @@ export default function CigaretteFagerstromTest(): ReactNode {
             {errors.smokeWhenSickInBed?.message}
           </FormHelperText>
         </FormControl>
+
+        <LoadingButton
+          type="submit"
+          variant="contained"
+          color="primary"
+          loading={false}
+        >
+          Submit
+        </LoadingButton>
+
+        <Typography variant="h6" fontWeight="normal" color="red">
+          {errors.root?.message}
+        </Typography>
       </Box>
     </form>
   );

--- a/src/components/ClientDashboard/RigsWithoutCigs/FagerstromTest/CigaretteFagerstromTest.tsx
+++ b/src/components/ClientDashboard/RigsWithoutCigs/FagerstromTest/CigaretteFagerstromTest.tsx
@@ -1,6 +1,235 @@
-import { Typography } from "@mui/material";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  Box,
+  FormControl,
+  FormControlLabel,
+  FormHelperText,
+  FormLabel,
+  Radio,
+  RadioGroup,
+} from "@mui/material";
 import { ReactNode } from "react";
+import { Controller, useForm } from "react-hook-form";
+
+import {
+  CigaretteFagerstromTestForm,
+  cigaretteFagerstromTestFormValidator,
+} from "@/types/FagerstromTestForm/CigaretteFagerstromTestForm";
 
 export default function CigaretteFagerstromTest(): ReactNode {
-  return <Typography>Cigarette Fagerstrom Test</Typography>;
+  const {
+    control,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<CigaretteFagerstromTestForm>({
+    resolver: zodResolver(cigaretteFagerstromTestFormValidator),
+    defaultValues: {
+      firstCigarette: 0,
+      refrainInForbiddenAreas: 0,
+      whichGiveUpHate: 0,
+      cigarettesPerDay: 0,
+      frequentlyInMorning: 0,
+      smokeWhenSickInBed: 0,
+    },
+  });
+
+  const onSubmit = (data: CigaretteFagerstromTestForm): void => {
+    // eslint-disable-next-line no-console
+    console.log(data);
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <Box
+        sx={{
+          width: "min(90vw, 700px)",
+          display: "grid",
+          gap: 1.5,
+          gridTemplateColumns: "1fr",
+        }}
+      >
+        <FormControl
+          error={!!errors.firstCigarette?.message}
+          sx={{ width: "100%" }}
+        >
+          <FormLabel>
+            How soon after waking do you smoke your first cigarette?
+          </FormLabel>
+          <Controller
+            name="firstCigarette"
+            control={control}
+            render={({ field }) => (
+              <RadioGroup
+                {...field}
+                value={field.value.toString()}
+                onChange={(e) => field.onChange(Number(e.target.value))}
+              >
+                <FormControlLabel
+                  value="3"
+                  control={<Radio />}
+                  label="Within 5 minutes"
+                />
+                <FormControlLabel
+                  value="2"
+                  control={<Radio />}
+                  label="5-30 minutes"
+                />
+                <FormControlLabel
+                  value="1"
+                  control={<Radio />}
+                  label="31-60 minutes"
+                />
+              </RadioGroup>
+            )}
+          />
+          <FormHelperText sx={{ m: 0 }}>
+            {errors.firstCigarette?.message}
+          </FormHelperText>
+        </FormControl>
+
+        <FormControl
+          error={!!errors.refrainInForbiddenAreas?.message}
+          sx={{ width: "100%" }}
+        >
+          <FormLabel>
+            Do you find it difficult to refrain from smoking in places where it
+            is forbidden?
+          </FormLabel>
+          <Controller
+            name="refrainInForbiddenAreas"
+            control={control}
+            render={({ field }) => (
+              <RadioGroup
+                {...field}
+                value={field.value.toString()}
+                onChange={(e) => field.onChange(Number(e.target.value))}
+              >
+                <FormControlLabel value="1" control={<Radio />} label="Yes" />
+                <FormControlLabel value="0" control={<Radio />} label="No" />
+              </RadioGroup>
+            )}
+          />
+          <FormHelperText sx={{ m: 0 }}>
+            {errors.refrainInForbiddenAreas?.message}
+          </FormHelperText>
+        </FormControl>
+
+        <FormControl
+          error={!!errors.whichGiveUpHate?.message}
+          sx={{ width: "100%" }}
+        >
+          <FormLabel>Which cigarette would you hate to give up?</FormLabel>
+          <Controller
+            name="whichGiveUpHate"
+            control={control}
+            render={({ field }) => (
+              <RadioGroup
+                {...field}
+                value={field.value.toString()}
+                onChange={(e) => field.onChange(Number(e.target.value))}
+              >
+                <FormControlLabel
+                  value="1"
+                  control={<Radio />}
+                  label="The first one in the morning morning"
+                />
+                <FormControlLabel
+                  value="0"
+                  control={<Radio />}
+                  label="All others"
+                />
+              </RadioGroup>
+            )}
+          />
+          <FormHelperText sx={{ m: 0 }}>
+            {errors.whichGiveUpHate?.message}
+          </FormHelperText>
+        </FormControl>
+
+        <FormControl
+          error={!!errors.cigarettesPerDay?.message}
+          sx={{ width: "100%" }}
+        >
+          <FormLabel>How many cigarettes a day do you smoke?</FormLabel>
+          <Controller
+            name="cigarettesPerDay"
+            control={control}
+            render={({ field }) => (
+              <RadioGroup
+                {...field}
+                value={field.value.toString()}
+                onChange={(e) => field.onChange(Number(e.target.value))}
+              >
+                <FormControlLabel
+                  value="0"
+                  control={<Radio />}
+                  label="10 or less"
+                />
+                <FormControlLabel value="1" control={<Radio />} label="11-20" />
+                <FormControlLabel value="2" control={<Radio />} label="21-30" />
+                <FormControlLabel
+                  value="3"
+                  control={<Radio />}
+                  label="31 or more"
+                />
+              </RadioGroup>
+            )}
+          />
+          <FormHelperText sx={{ m: 0 }}>
+            {errors.cigarettesPerDay?.message}
+          </FormHelperText>
+        </FormControl>
+
+        <FormControl
+          error={!!errors.frequentlyInMorning?.message}
+          sx={{ width: "100%" }}
+        >
+          <FormLabel>Do you smoke more frequently in the morning?</FormLabel>
+          <Controller
+            name="frequentlyInMorning"
+            control={control}
+            render={({ field }) => (
+              <RadioGroup
+                {...field}
+                value={field.value.toString()}
+                onChange={(e) => field.onChange(Number(e.target.value))}
+              >
+                <FormControlLabel value="1" control={<Radio />} label="Yes" />
+                <FormControlLabel value="0" control={<Radio />} label="No" />
+              </RadioGroup>
+            )}
+          />
+          <FormHelperText sx={{ m: 0 }}>
+            {errors.frequentlyInMorning?.message}
+          </FormHelperText>
+        </FormControl>
+
+        <FormControl
+          error={!!errors.smokeWhenSickInBed?.message}
+          sx={{ width: "100%" }}
+        >
+          <FormLabel>
+            Do you moke even if you are sick in bed most of the day?
+          </FormLabel>
+          <Controller
+            name="smokeWhenSickInBed"
+            control={control}
+            render={({ field }) => (
+              <RadioGroup
+                {...field}
+                value={field.value.toString()}
+                onChange={(e) => field.onChange(Number(e.target.value))}
+              >
+                <FormControlLabel value="1" control={<Radio />} label="Yes" />
+                <FormControlLabel value="0" control={<Radio />} label="No" />
+              </RadioGroup>
+            )}
+          />
+          <FormHelperText sx={{ m: 0 }}>
+            {errors.smokeWhenSickInBed?.message}
+          </FormHelperText>
+        </FormControl>
+      </Box>
+    </form>
+  );
 }

--- a/src/components/ClientDashboard/RigsWithoutCigs/FagerstromTest/CigaretteFagerstromTest.tsx
+++ b/src/components/ClientDashboard/RigsWithoutCigs/FagerstromTest/CigaretteFagerstromTest.tsx
@@ -26,12 +26,12 @@ export default function CigaretteFagerstromTest(): ReactNode {
   } = useForm<CigaretteFagerstromTestForm>({
     resolver: zodResolver(cigaretteFagerstromTestFormValidator),
     defaultValues: {
-      firstCigarette: -1,
-      refrainInForbiddenAreas: -1,
-      whichGiveUpHate: -1,
-      cigarettesPerDay: -1,
-      frequentlyInMorning: -1,
-      smokeWhenSickInBed: -1,
+      firstCigarette: 3,
+      refrainInForbiddenAreas: 1,
+      whichGiveUpHate: 1,
+      cigarettesPerDay: 0,
+      frequentlyInMorning: 1,
+      smokeWhenSickInBed: 1,
     },
   });
 
@@ -48,6 +48,7 @@ export default function CigaretteFagerstromTest(): ReactNode {
           display: "grid",
           gap: 1.5,
           gridTemplateColumns: "1fr",
+          marginInline: "auto",
         }}
       >
         <FormControl

--- a/src/components/ClientDashboard/RigsWithoutCigs/FagerstromTest/SmokelessTobaccoFagerstromTest.tsx
+++ b/src/components/ClientDashboard/RigsWithoutCigs/FagerstromTest/SmokelessTobaccoFagerstromTest.tsx
@@ -1,0 +1,6 @@
+import { Typography } from "@mui/material";
+import { ReactNode } from "react";
+
+export default function SmokelessTobaccoFagerstromTest(): ReactNode {
+  return <Typography>Smokeless Tobacco Fagerstrom Test</Typography>;
+}

--- a/src/components/ClientDashboard/RigsWithoutCigs/FagerstromTest/SmokelessTobaccoFagerstromTest.tsx
+++ b/src/components/ClientDashboard/RigsWithoutCigs/FagerstromTest/SmokelessTobaccoFagerstromTest.tsx
@@ -24,12 +24,12 @@ export default function SmokelessTobaccoFagerstromTest(): ReactNode {
   } = useForm<SmokelessTobaccoFagerstromTestForm>({
     resolver: zodResolver(smokelessTobaccoFagerstromTestFormValidator),
     defaultValues: {
-      firstDip: 0,
-      intentionallySwallow: 0,
-      whichGiveUpHate: 0,
-      dipPerWeek: 0,
-      frequentlyInMorning: 0,
-      dipWhenSickInBed: 0,
+      firstDip: -1,
+      intentionallySwallow: -1,
+      whichGiveUpHate: -1,
+      dipPerWeek: -1,
+      frequentlyInMorning: -1,
+      dipWhenSickInBed: -1,
     },
   });
 
@@ -116,7 +116,6 @@ export default function SmokelessTobaccoFagerstromTest(): ReactNode {
                   label="Sometimes"
                 />
                 <FormControlLabel value="0" control={<Radio />} label="Never" />
-                <FormControlLabel value="0" control={<Radio />} label="Never" />
               </RadioGroup>
             )}
           />
@@ -178,11 +177,6 @@ export default function SmokelessTobaccoFagerstromTest(): ReactNode {
                 />
                 <FormControlLabel value="1" control={<Radio />} label="2-3" />
                 <FormControlLabel value="0" control={<Radio />} label="0" />
-                <FormControlLabel
-                  value="0"
-                  control={<Radio />}
-                  label="Not Applicable"
-                />
               </RadioGroup>
             )}
           />

--- a/src/components/ClientDashboard/RigsWithoutCigs/FagerstromTest/SmokelessTobaccoFagerstromTest.tsx
+++ b/src/components/ClientDashboard/RigsWithoutCigs/FagerstromTest/SmokelessTobaccoFagerstromTest.tsx
@@ -1,6 +1,246 @@
-import { Typography } from "@mui/material";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  Box,
+  FormControl,
+  FormControlLabel,
+  FormHelperText,
+  FormLabel,
+  Radio,
+  RadioGroup,
+} from "@mui/material";
 import { ReactNode } from "react";
+import { Controller, useForm } from "react-hook-form";
+
+import {
+  SmokelessTobaccoFagerstromTestForm,
+  smokelessTobaccoFagerstromTestFormValidator,
+} from "@/types/FagerstromTestForm/SmokelessTobaccoFagerstromTestForm";
 
 export default function SmokelessTobaccoFagerstromTest(): ReactNode {
-  return <Typography>Smokeless Tobacco Fagerstrom Test</Typography>;
+  const {
+    control,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<SmokelessTobaccoFagerstromTestForm>({
+    resolver: zodResolver(smokelessTobaccoFagerstromTestFormValidator),
+    defaultValues: {
+      firstDip: 0,
+      intentionallySwallow: 0,
+      whichGiveUpHate: 0,
+      dipPerWeek: 0,
+      frequentlyInMorning: 0,
+      dipWhenSickInBed: 0,
+    },
+  });
+
+  const onSubmit = (data: SmokelessTobaccoFagerstromTestForm): void => {
+    // eslint-disable-next-line no-console
+    console.log(data);
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <Box
+        sx={{
+          width: "min(90vw, 700px)",
+          display: "grid",
+          gap: 1.5,
+          gridTemplateColumns: "1fr",
+        }}
+      >
+        <FormControl error={!!errors.firstDip?.message} sx={{ width: "100%" }}>
+          <FormLabel>
+            How soon after you wake up do you place your first dip?
+          </FormLabel>
+          <Controller
+            name="firstDip"
+            control={control}
+            render={({ field }) => (
+              <RadioGroup
+                {...field}
+                value={field.value.toString()}
+                onChange={(e) => field.onChange(Number(e.target.value))}
+              >
+                <FormControlLabel
+                  value="3"
+                  control={<Radio />}
+                  label="Within 5 minutes"
+                />
+                <FormControlLabel
+                  value="2"
+                  control={<Radio />}
+                  label="5-30 minutes"
+                />
+                <FormControlLabel
+                  value="1"
+                  control={<Radio />}
+                  label="31-60 minutes"
+                />
+                <FormControlLabel
+                  value="0"
+                  control={<Radio />}
+                  label="After 60 minutes"
+                />
+              </RadioGroup>
+            )}
+          />
+          <FormHelperText sx={{ m: 0 }}>
+            {errors.firstDip?.message}
+          </FormHelperText>
+        </FormControl>
+
+        <FormControl
+          error={!!errors.intentionallySwallow?.message}
+          sx={{ width: "100%" }}
+        >
+          <FormLabel>
+            How often do you intentionally swallow tobacco juice?
+          </FormLabel>
+          <Controller
+            name="intentionallySwallow"
+            control={control}
+            render={({ field }) => (
+              <RadioGroup
+                {...field}
+                value={field.value.toString()}
+                onChange={(e) => field.onChange(Number(e.target.value))}
+              >
+                <FormControlLabel
+                  value="2"
+                  control={<Radio />}
+                  label="Always"
+                />
+                <FormControlLabel
+                  value="1"
+                  control={<Radio />}
+                  label="Sometimes"
+                />
+                <FormControlLabel value="0" control={<Radio />} label="Never" />
+                <FormControlLabel value="0" control={<Radio />} label="Never" />
+              </RadioGroup>
+            )}
+          />
+          <FormHelperText sx={{ m: 0 }}>
+            {errors.intentionallySwallow?.message}
+          </FormHelperText>
+        </FormControl>
+
+        <FormControl
+          error={!!errors.whichGiveUpHate?.message}
+          sx={{ width: "100%" }}
+        >
+          <FormLabel>Which chew would you hate to give up?</FormLabel>
+          <Controller
+            name="whichGiveUpHate"
+            control={control}
+            render={({ field }) => (
+              <RadioGroup
+                {...field}
+                value={field.value.toString()}
+                onChange={(e) => field.onChange(Number(e.target.value))}
+              >
+                <FormControlLabel
+                  value="1"
+                  control={<Radio />}
+                  label="The first one in the morning"
+                />
+                <FormControlLabel
+                  value="0"
+                  control={<Radio />}
+                  label="All others"
+                />
+              </RadioGroup>
+            )}
+          />
+          <FormHelperText sx={{ m: 0 }}>
+            {errors.whichGiveUpHate?.message}
+          </FormHelperText>
+        </FormControl>
+
+        <FormControl
+          error={!!errors.dipPerWeek?.message}
+          sx={{ width: "100%" }}
+        >
+          <FormLabel>How many cans/pouches per week do you use</FormLabel>
+          <Controller
+            name="dipPerWeek"
+            control={control}
+            render={({ field }) => (
+              <RadioGroup
+                {...field}
+                value={field.value.toString()}
+                onChange={(e) => field.onChange(Number(e.target.value))}
+              >
+                <FormControlLabel
+                  value="2"
+                  control={<Radio />}
+                  label="More than 3"
+                />
+                <FormControlLabel value="1" control={<Radio />} label="2-3" />
+                <FormControlLabel value="0" control={<Radio />} label="0" />
+                <FormControlLabel
+                  value="0"
+                  control={<Radio />}
+                  label="Not Applicable"
+                />
+              </RadioGroup>
+            )}
+          />
+          <FormHelperText sx={{ m: 0 }}>
+            {errors.dipPerWeek?.message}
+          </FormHelperText>
+        </FormControl>
+
+        <FormControl
+          error={!!errors.frequentlyInMorning?.message}
+          sx={{ width: "100%" }}
+        >
+          <FormLabel>Do you chew more frequently in the morning?</FormLabel>
+          <Controller
+            name="frequentlyInMorning"
+            control={control}
+            render={({ field }) => (
+              <RadioGroup
+                {...field}
+                value={field.value.toString()}
+                onChange={(e) => field.onChange(Number(e.target.value))}
+              >
+                <FormControlLabel value="1" control={<Radio />} label="Yes" />
+                <FormControlLabel value="0" control={<Radio />} label="No" />
+              </RadioGroup>
+            )}
+          />
+          <FormHelperText sx={{ m: 0 }}>
+            {errors.frequentlyInMorning?.message}
+          </FormHelperText>
+        </FormControl>
+
+        <FormControl
+          error={!!errors.dipWhenSickInBed?.message}
+          sx={{ width: "100%" }}
+        >
+          <FormLabel>
+            Do you chew even if you are sick in bed most of the day?
+          </FormLabel>
+          <Controller
+            name="dipWhenSickInBed"
+            control={control}
+            render={({ field }) => (
+              <RadioGroup
+                {...field}
+                value={field.value.toString()}
+                onChange={(e) => field.onChange(Number(e.target.value))}
+              >
+                <FormControlLabel value="1" control={<Radio />} label="Yes" />
+                <FormControlLabel value="0" control={<Radio />} label="No" />
+              </RadioGroup>
+            )}
+          />
+          <FormHelperText sx={{ m: 0 }}>
+            {errors.dipWhenSickInBed?.message}
+          </FormHelperText>
+        </FormControl>
+      </Box>
+    </form>
+  );
 }

--- a/src/components/ClientDashboard/RigsWithoutCigs/FagerstromTest/SmokelessTobaccoFagerstromTest.tsx
+++ b/src/components/ClientDashboard/RigsWithoutCigs/FagerstromTest/SmokelessTobaccoFagerstromTest.tsx
@@ -26,12 +26,12 @@ export default function SmokelessTobaccoFagerstromTest(): ReactNode {
   } = useForm<SmokelessTobaccoFagerstromTestForm>({
     resolver: zodResolver(smokelessTobaccoFagerstromTestFormValidator),
     defaultValues: {
-      firstDip: -1,
-      intentionallySwallow: -1,
-      whichGiveUpHate: -1,
-      dipPerWeek: -1,
-      frequentlyInMorning: -1,
-      dipWhenSickInBed: -1,
+      firstDip: 3,
+      intentionallySwallow: 2,
+      whichGiveUpHate: 1,
+      dipPerWeek: 2,
+      frequentlyInMorning: 1,
+      dipWhenSickInBed: 1,
     },
   });
 
@@ -48,6 +48,7 @@ export default function SmokelessTobaccoFagerstromTest(): ReactNode {
           display: "grid",
           gap: 1.5,
           gridTemplateColumns: "1fr",
+          marginInline: "auto",
         }}
       >
         <FormControl error={!!errors.firstDip?.message} sx={{ width: "100%" }}>

--- a/src/components/ClientDashboard/RigsWithoutCigs/FagerstromTest/SmokelessTobaccoFagerstromTest.tsx
+++ b/src/components/ClientDashboard/RigsWithoutCigs/FagerstromTest/SmokelessTobaccoFagerstromTest.tsx
@@ -1,4 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod";
+import LoadingButton from "@mui/lab/LoadingButton";
 import {
   Box,
   FormControl,
@@ -7,6 +8,7 @@ import {
   FormLabel,
   Radio,
   RadioGroup,
+  Typography,
 } from "@mui/material";
 import { ReactNode } from "react";
 import { Controller, useForm } from "react-hook-form";
@@ -234,6 +236,19 @@ export default function SmokelessTobaccoFagerstromTest(): ReactNode {
             {errors.dipWhenSickInBed?.message}
           </FormHelperText>
         </FormControl>
+
+        <LoadingButton
+          type="submit"
+          variant="contained"
+          color="primary"
+          loading={false}
+        >
+          Submit
+        </LoadingButton>
+
+        <Typography variant="h6" fontWeight="normal" color="red">
+          {errors.root?.message}
+        </Typography>
       </Box>
     </form>
   );

--- a/src/components/ClientDashboard/RigsWithoutCigs/FagerstromTest/index.tsx
+++ b/src/components/ClientDashboard/RigsWithoutCigs/FagerstromTest/index.tsx
@@ -35,7 +35,7 @@ export default function FagerstromTest(): ReactNode {
         sx={{
           display: "flex",
           justifyContent: "center",
-          alignItems: "start",
+          alignItems: "center",
           flexDirection: "column",
         }}
       >

--- a/src/components/ClientDashboard/RigsWithoutCigs/FagerstromTest/index.tsx
+++ b/src/components/ClientDashboard/RigsWithoutCigs/FagerstromTest/index.tsx
@@ -2,20 +2,12 @@
 import { Box, Divider, Tab, Tabs, Typography } from "@mui/material";
 import { ReactNode, SyntheticEvent, useState } from "react";
 
-import { ClientUser } from "@/types";
-
 import CigaretteFagerstromTest from "./CigaretteFagerstromTest";
 import SmokelessTobaccoFagerstromTest from "./SmokelessTobaccoFagerstromTest";
 
 type FagerstromTestSections = "cigarette" | "smokeless_tobacco";
 
-type FagerstromTestProps = {
-  user: ClientUser;
-};
-
-export default function FagerstromTest({
-  user,
-}: FagerstromTestProps): ReactNode {
+export default function FagerstromTest(): ReactNode {
   const [selectedSection, setSelectedSection] =
     useState<FagerstromTestSections>("cigarette");
 
@@ -43,13 +35,10 @@ export default function FagerstromTest({
         sx={{
           display: "flex",
           justifyContent: "center",
-          alignItems: "center",
+          alignItems: "start",
           flexDirection: "column",
         }}
       >
-        <Typography sx={{ fontSize: "1.5rem", marginBottom: 2 }}>
-          Fagerstrom Test
-        </Typography>
         <Tabs
           value={selectedSection}
           onChange={handleTabChange}

--- a/src/components/ClientDashboard/RigsWithoutCigs/FagerstromTest/index.tsx
+++ b/src/components/ClientDashboard/RigsWithoutCigs/FagerstromTest/index.tsx
@@ -1,0 +1,68 @@
+"use client";
+import { Box, Divider, Tab, Tabs, Typography } from "@mui/material";
+import { ReactNode, SyntheticEvent, useState } from "react";
+
+import { ClientUser } from "@/types";
+
+import CigaretteFagerstromTest from "./CigaretteFagerstromTest";
+import SmokelessTobaccoFagerstromTest from "./SmokelessTobaccoFagerstromTest";
+
+type FagerstromTestSections = "cigarette" | "smokeless_tobacco";
+
+type FagerstromTestProps = {
+  user: ClientUser;
+};
+
+export default function FagerstromTest({
+  user,
+}: FagerstromTestProps): ReactNode {
+  const [selectedSection, setSelectedSection] =
+    useState<FagerstromTestSections>("cigarette");
+
+  const handleTabChange = (
+    _event: SyntheticEvent,
+    newValue: FagerstromTestSections,
+  ): void => {
+    setSelectedSection(newValue);
+  };
+
+  function getSectionContent(section: FagerstromTestSections): ReactNode {
+    switch (section) {
+      case "cigarette":
+        return <CigaretteFagerstromTest />;
+      case "smokeless_tobacco":
+        return <SmokelessTobaccoFagerstromTest />;
+      default:
+        return <Typography>Invalid section</Typography>;
+    }
+  }
+
+  return (
+    <>
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          flexDirection: "column",
+        }}
+      >
+        <Typography sx={{ fontSize: "1.5rem", marginBottom: 2 }}>
+          Fagerstrom Test
+        </Typography>
+        <Tabs
+          value={selectedSection}
+          onChange={handleTabChange}
+          indicatorColor="primary"
+          textColor="primary"
+          centered
+        >
+          <Tab label="Cigarette" value="cigarette" />
+          <Tab label="Smokeless Tobacco" value="smokeless_tobacco" />
+        </Tabs>
+      </Box>
+      <Divider sx={{ width: "80vw", marginTop: 2 }} />
+      <Box sx={{ marginTop: 3 }}>{getSectionContent(selectedSection)}</Box>
+    </>
+  );
+}

--- a/src/components/ClientDashboard/RigsWithoutCigs/RigsWithoutCigsHistory.tsx
+++ b/src/components/ClientDashboard/RigsWithoutCigs/RigsWithoutCigsHistory.tsx
@@ -1,4 +1,5 @@
 import { Typography } from "@mui/material";
+import dayjs from "dayjs";
 import { ReactNode } from "react";
 
 import { ClientUser } from "@/types";
@@ -10,5 +11,25 @@ type RigsWithoutCigsHistoryProps = {
 export default function RigsWithoutCigsHistory({
   user,
 }: RigsWithoutCigsHistoryProps): ReactNode {
-  return <Typography>Rigs Without Cigs History</Typography>;
+  const daysSinceStartOfProgram = dayjs(user.enrollmentForm.dateSubmitted).diff(
+    dayjs(),
+    "day",
+  );
+  const moneySaved =
+    user.enrollmentForm.programSpecificQuestionsSection.rigsWithoutCigs
+      .cigarettesPerDay *
+    0.4 *
+    daysSinceStartOfProgram;
+
+  return (
+    <>
+      <Typography>Rigs Without Cigs History</Typography>
+      <Typography>Money saved: ${moneySaved.toFixed(2)}</Typography>
+      <Typography>
+        Tobacco Free for: {daysSinceStartOfProgram} day
+        {daysSinceStartOfProgram % 2 === 0 ? "s" : ""}
+      </Typography>
+      <Typography>Next prize in: 2 days</Typography>
+    </>
+  );
 }

--- a/src/components/ClientDashboard/RigsWithoutCigs/RigsWithoutCigsHistory.tsx
+++ b/src/components/ClientDashboard/RigsWithoutCigs/RigsWithoutCigsHistory.tsx
@@ -1,0 +1,14 @@
+import { Typography } from "@mui/material";
+import { ReactNode } from "react";
+
+import { ClientUser } from "@/types";
+
+type RigsWithoutCigsHistoryProps = {
+  user: ClientUser;
+};
+
+export default function RigsWithoutCigsHistory({
+  user,
+}: RigsWithoutCigsHistoryProps): ReactNode {
+  return <Typography>Rigs Without Cigs History</Typography>;
+}

--- a/src/components/ClientDashboard/RigsWithoutCigs/RigsWithoutCigsHistory.tsx
+++ b/src/components/ClientDashboard/RigsWithoutCigs/RigsWithoutCigsHistory.tsx
@@ -11,19 +11,20 @@ type RigsWithoutCigsHistoryProps = {
 export default function RigsWithoutCigsHistory({
   user,
 }: RigsWithoutCigsHistoryProps): ReactNode {
+  const PRICE_PER_CIGARETTE = 0.4;
   const daysSinceStartOfProgram = dayjs(user.enrollmentForm.dateSubmitted).diff(
     dayjs(),
     "day",
   );
+
   const moneySaved =
     user.enrollmentForm.programSpecificQuestionsSection.rigsWithoutCigs
       .cigarettesPerDay *
-    0.4 *
+    PRICE_PER_CIGARETTE *
     daysSinceStartOfProgram;
 
   return (
     <>
-      <Typography>Rigs Without Cigs History</Typography>
       <Typography>Money saved: ${moneySaved.toFixed(2)}</Typography>
       <Typography>
         Tobacco Free for: {daysSinceStartOfProgram} day

--- a/src/components/ClientDashboard/RigsWithoutCigs/RigsWithoutCigsHistory.tsx
+++ b/src/components/ClientDashboard/RigsWithoutCigs/RigsWithoutCigsHistory.tsx
@@ -1,19 +1,21 @@
-import { Typography } from "@mui/material";
-import dayjs from "dayjs";
+import { Box, Typography } from "@mui/material";
 import { ReactNode } from "react";
 
-import { ClientUser } from "@/types";
+import { ClientUser, ProgramEnrollment } from "@/types";
+import dayjsUtil from "@/utils/dayjsUtil";
 
 type RigsWithoutCigsHistoryProps = {
   user: ClientUser;
+  programEnrollment: ProgramEnrollment;
 };
 
 export default function RigsWithoutCigsHistory({
   user,
+  programEnrollment,
 }: RigsWithoutCigsHistoryProps): ReactNode {
   const PRICE_PER_CIGARETTE = 0.4;
-  const daysSinceStartOfProgram = dayjs(user.enrollmentForm.dateSubmitted).diff(
-    dayjs(),
+  const daysSinceStartOfProgram = dayjsUtil().diff(
+    dayjsUtil(programEnrollment.dateEnrolled),
     "day",
   );
 
@@ -24,13 +26,29 @@ export default function RigsWithoutCigsHistory({
     daysSinceStartOfProgram;
 
   return (
-    <>
-      <Typography>Money saved: ${moneySaved.toFixed(2)}</Typography>
-      <Typography>
-        Tobacco Free for: {daysSinceStartOfProgram} day
-        {daysSinceStartOfProgram % 2 === 0 ? "s" : ""}
+    <Box
+      sx={{
+        width: "min(90vw, 700px)",
+        boxShadow: 3,
+        borderRadius: 2,
+        padding: 4,
+      }}
+    >
+      <Typography variant="h5" textAlign="center" gutterBottom>
+        History
       </Typography>
-      <Typography>Next prize in: 2 days</Typography>
-    </>
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+        <Typography>
+          <strong>Money Saved:</strong> ${moneySaved.toFixed(2)}
+        </Typography>
+        <Typography>
+          <strong>Tobacco Free for:</strong> {daysSinceStartOfProgram} day
+          {daysSinceStartOfProgram !== 1 ? "s" : ""}
+        </Typography>
+        <Typography>
+          <strong>Next prize in:</strong> 2 days
+        </Typography>
+      </Box>
+    </Box>
   );
 }

--- a/src/components/ClientDashboard/RigsWithoutCigs/RigsWithoutCigsInfo.tsx
+++ b/src/components/ClientDashboard/RigsWithoutCigs/RigsWithoutCigsInfo.tsx
@@ -1,4 +1,4 @@
-import { Typography } from "@mui/material";
+import { Box, Typography } from "@mui/material";
 import { ReactNode } from "react";
 
 import { ClientUser } from "@/types";
@@ -15,14 +15,29 @@ export default function RigsWithoutCigsInfo({
       .accountabilityPerson;
 
   return (
-    <>
-      <Typography>
-        Accountability Person: {accountabilityPerson.firstName}{" "}
-        {accountabilityPerson.lastName} |{" "}
-        <a href={`tel:${accountabilityPerson.phoneNumber}`}>
-          {accountabilityPerson.phoneNumber}
-        </a>
+    <Box
+      sx={{
+        width: "min(90vw, 700px)",
+        boxShadow: 3,
+        borderRadius: 2,
+        padding: 4,
+      }}
+    >
+      <Typography variant="h5" textAlign="center" gutterBottom>
+        Info
       </Typography>
-    </>
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+        <Typography>
+          <strong>Accountability Person:</strong>{" "}
+          {accountabilityPerson.firstName} {accountabilityPerson.lastName}
+        </Typography>
+        <Typography>
+          <strong>Phone Number:</strong>{" "}
+          <a href={`tel:${accountabilityPerson.phoneNumber}`}>
+            {accountabilityPerson.phoneNumber}
+          </a>
+        </Typography>
+      </Box>
+    </Box>
   );
 }

--- a/src/components/ClientDashboard/RigsWithoutCigs/RigsWithoutCigsInfo.tsx
+++ b/src/components/ClientDashboard/RigsWithoutCigs/RigsWithoutCigsInfo.tsx
@@ -1,0 +1,6 @@
+import { Typography } from "@mui/material";
+import { ReactNode } from "react";
+
+export default function RigsWithoutCigsInfo(): ReactNode {
+  return <Typography>Rigs Without Cigs Info</Typography>;
+}

--- a/src/components/ClientDashboard/RigsWithoutCigs/RigsWithoutCigsInfo.tsx
+++ b/src/components/ClientDashboard/RigsWithoutCigs/RigsWithoutCigsInfo.tsx
@@ -1,6 +1,26 @@
 import { Typography } from "@mui/material";
 import { ReactNode } from "react";
 
-export default function RigsWithoutCigsInfo(): ReactNode {
-  return <Typography>Rigs Without Cigs Info</Typography>;
+import { ClientUser } from "@/types";
+
+type RigsWithoutCigsInfoProps = {
+  user: ClientUser;
+};
+
+export default function RigsWithoutCigsInfo({
+  user,
+}: RigsWithoutCigsInfoProps): ReactNode {
+  const accountabilityPerson =
+    user.enrollmentForm.programSpecificQuestionsSection.rigsWithoutCigs
+      .accountabilityPerson;
+
+  return (
+    <>
+      <Typography>Rigs Without Cigs Info</Typography>
+      <Typography>
+        Accountability Person: {accountabilityPerson.firstName}{" "}
+        {accountabilityPerson.lastName} | {accountabilityPerson.phoneNumber}
+      </Typography>
+    </>
+  );
 }

--- a/src/components/ClientDashboard/RigsWithoutCigs/RigsWithoutCigsInfo.tsx
+++ b/src/components/ClientDashboard/RigsWithoutCigs/RigsWithoutCigsInfo.tsx
@@ -16,10 +16,12 @@ export default function RigsWithoutCigsInfo({
 
   return (
     <>
-      <Typography>Rigs Without Cigs Info</Typography>
       <Typography>
         Accountability Person: {accountabilityPerson.firstName}{" "}
-        {accountabilityPerson.lastName} | {accountabilityPerson.phoneNumber}
+        {accountabilityPerson.lastName} |{" "}
+        <a href={`tel:${accountabilityPerson.phoneNumber}`}>
+          {accountabilityPerson.phoneNumber}
+        </a>
       </Typography>
     </>
   );

--- a/src/components/ClientDashboard/RigsWithoutCigs/index.tsx
+++ b/src/components/ClientDashboard/RigsWithoutCigs/index.tsx
@@ -30,11 +30,11 @@ export default function RigsWithoutCigs({
   function getSectionContent(section: RigsWithoutCigsSections): ReactNode {
     switch (section) {
       case "fagerstrom_test":
-        return <FagerstromTest user={user} />;
+        return <FagerstromTest />;
       case "history":
         return <RigsWithoutCigsHistory user={user} />;
       case "info":
-        return <RigsWithoutCigsInfo />;
+        return <RigsWithoutCigsInfo user={user} />;
       default:
         return <Typography>Invalid section</Typography>;
     }

--- a/src/components/ClientDashboard/RigsWithoutCigs/index.tsx
+++ b/src/components/ClientDashboard/RigsWithoutCigs/index.tsx
@@ -2,7 +2,7 @@
 import { Box, Divider, Tab, Tabs, Typography } from "@mui/material";
 import { ReactNode, SyntheticEvent, useState } from "react";
 
-import { ClientUser } from "@/types";
+import { ClientUser, ProgramEnrollment } from "@/types";
 
 import FagerstromTest from "./FagerstromTest";
 import RigsWithoutCigsHistory from "./RigsWithoutCigsHistory";
@@ -12,10 +12,12 @@ type RigsWithoutCigsSections = "fagerstrom_test" | "history" | "info";
 
 type RigsWithoutCigsProps = {
   user: ClientUser;
+  programEnrollment: ProgramEnrollment;
 };
 
 export default function RigsWithoutCigs({
   user,
+  programEnrollment,
 }: RigsWithoutCigsProps): ReactNode {
   const [selectedSection, setSelectedSection] =
     useState<RigsWithoutCigsSections>("fagerstrom_test");
@@ -32,7 +34,12 @@ export default function RigsWithoutCigs({
       case "fagerstrom_test":
         return <FagerstromTest />;
       case "history":
-        return <RigsWithoutCigsHistory user={user} />;
+        return (
+          <RigsWithoutCigsHistory
+            user={user}
+            programEnrollment={programEnrollment}
+          />
+        );
       case "info":
         return <RigsWithoutCigsInfo user={user} />;
       default:

--- a/src/components/ClientDashboard/RigsWithoutCigs/index.tsx
+++ b/src/components/ClientDashboard/RigsWithoutCigs/index.tsx
@@ -1,0 +1,72 @@
+"use client";
+import { Box, Divider, Tab, Tabs, Typography } from "@mui/material";
+import { ReactNode, SyntheticEvent, useState } from "react";
+
+import { ClientUser } from "@/types";
+
+import FagerstromTest from "./FagerstromTest";
+import RigsWithoutCigsHistory from "./RigsWithoutCigsHistory";
+import RigsWithoutCigsInfo from "./RigsWithoutCigsInfo";
+
+type RigsWithoutCigsSections = "fagerstrom_test" | "history" | "info";
+
+type RigsWithoutCigsProps = {
+  user: ClientUser;
+};
+
+export default function RigsWithoutCigs({
+  user,
+}: RigsWithoutCigsProps): ReactNode {
+  const [selectedSection, setSelectedSection] =
+    useState<RigsWithoutCigsSections>("fagerstrom_test");
+
+  const handleTabChange = (
+    _event: SyntheticEvent,
+    newValue: RigsWithoutCigsSections,
+  ): void => {
+    setSelectedSection(newValue);
+  };
+
+  function getSectionContent(section: RigsWithoutCigsSections): ReactNode {
+    switch (section) {
+      case "fagerstrom_test":
+        return <FagerstromTest user={user} />;
+      case "history":
+        return <RigsWithoutCigsHistory user={user} />;
+      case "info":
+        return <RigsWithoutCigsInfo />;
+      default:
+        return <Typography>Invalid section</Typography>;
+    }
+  }
+
+  return (
+    <>
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          flexDirection: "column",
+        }}
+      >
+        <Typography sx={{ fontSize: "1.5rem", marginBottom: 2 }}>
+          Rigs Without Cigs Dashboard
+        </Typography>
+        <Tabs
+          value={selectedSection}
+          onChange={handleTabChange}
+          indicatorColor="primary"
+          textColor="primary"
+          centered
+        >
+          <Tab label="Fagerstrom Test" value="fagerstrom_test" />
+          <Tab label="History" value="history" />
+          <Tab label="Info" value="info" />
+        </Tabs>
+      </Box>
+      <Divider sx={{ width: "80vw", marginTop: 2 }} />
+      <Box sx={{ marginTop: 3 }}>{getSectionContent(selectedSection)}</Box>
+    </>
+  );
+}

--- a/src/server/api/program-enrollments/private-mutations.ts
+++ b/src/server/api/program-enrollments/private-mutations.ts
@@ -137,6 +137,7 @@ export async function approveProgramEnrollment(
   const [, updateProgramEnrollmentError] = await updateProgramEnrollment({
     ...programEnrollment,
     status: "accepted",
+    dateEnrolled: dayjsUtil().utc().toISOString(),
   });
 
   if (updateProgramEnrollmentError !== null) {

--- a/src/server/api/scheduled-meetings/private-mutations.ts
+++ b/src/server/api/scheduled-meetings/private-mutations.ts
@@ -23,7 +23,7 @@ export async function createScheduledMeeting(
     return [serializeMongooseObject(newScheduledMeetingDocument), null];
   } catch (error) {
     console.error(error);
-    return [null, serializeMongooseObject(error)];
+    return [null, handleMongooseError(error)];
   }
 }
 

--- a/src/server/api/scheduled-meetings/queries.ts
+++ b/src/server/api/scheduled-meetings/queries.ts
@@ -2,6 +2,7 @@ import dbConnect from "@/server/dbConnect";
 import { ScheduledMeetingModel } from "@/server/models";
 import { ApiResponse, ScheduledMeeting } from "@/types";
 import handleMongooseError from "@/utils/handleMongooseError";
+import { serializeMongooseObject } from "@/utils/serializeMongooseObject";
 
 export async function getAllScheduledMeetings(): Promise<
   ApiResponse<ScheduledMeeting[]>
@@ -20,7 +21,7 @@ export async function getAllScheduledMeetings(): Promise<
       .lean<ScheduledMeeting[]>()
       .exec();
 
-    return [scheduledMeetings, null];
+    return [serializeMongooseObject(scheduledMeetings), null];
   } catch (error) {
     console.error(error);
     return [null, handleMongooseError(error)];

--- a/src/server/api/users/queries.ts
+++ b/src/server/api/users/queries.ts
@@ -38,6 +38,10 @@ async function getUser(
       });
     }
 
+    if (options?.populateEnrollmentForm) {
+      userQuery.populate("enrollmentForm");
+    }
+
     const user = await userQuery.lean<User>().exec();
 
     if (!user) {

--- a/src/types/FagerstromTestForm/CigaretteFagerstromTestForm.ts
+++ b/src/types/FagerstromTestForm/CigaretteFagerstromTestForm.ts
@@ -1,0 +1,14 @@
+import z from "zod";
+
+export const cigaretteFagerstromTestFormValidator = z.object({
+  firstCigarette: z.number().min(1).max(3),
+  refrainInForbiddenAreas: z.number().min(0).max(1),
+  whichGiveUpHate: z.number().min(0).max(1),
+  cigarettesPerDay: z.number().min(0).max(3),
+  frequentlyInMorning: z.number().min(0).max(1),
+  smokeWhenSickInBed: z.number().min(0).max(1),
+});
+
+export type CigaretteFagerstromTestForm = z.infer<
+  typeof cigaretteFagerstromTestFormValidator
+>;

--- a/src/types/FagerstromTestForm/SmokelessTobaccoFagerstromTestForm.ts
+++ b/src/types/FagerstromTestForm/SmokelessTobaccoFagerstromTestForm.ts
@@ -1,0 +1,14 @@
+import z from "zod";
+
+export const smokelessTobaccoFagerstromTestFormValidator = z.object({
+  firstDip: z.number().min(0).max(3),
+  intentionallySwallow: z.number().min(0).max(2),
+  whichGiveUpHate: z.number().min(0).max(1),
+  dipPerWeek: z.number().min(0).max(2),
+  frequentlyInMorning: z.number().min(0).max(1),
+  dipWhenSickInBed: z.number().min(0).max(1),
+});
+
+export type SmokelessTobaccoFagerstromTestForm = z.infer<
+  typeof smokelessTobaccoFagerstromTestFormValidator
+>;


### PR DESCRIPTION
# Description
Created Rigs Without Cigs dashboard pages and tabs. Also created the two Fagerstrom tests. (The history and info pages need some design work...)

For the fagerstrom test, the from itself stores the score value of whatever they select and not the actual text of the choice. I guess we could calculate the full score on submit when we connect it to the db.

## Relevant Issues
#122 

## How to Test
Make a client user that is accepted to Rigs Without Cigs and does the appropriate enrollment form questions. Then go to the dashboard.