### PR TITLE
feat: added abstractions and implemented diabetes prevention admin dashboard

### DIFF
--- a/src/app/dashboard/admin/programs/diabetes-prevention/page.tsx
+++ b/src/app/dashboard/admin/programs/diabetes-prevention/page.tsx
@@ -1,17 +1,44 @@
 import { Box, Typography } from "@mui/material";
 import { ReactNode } from "react";
 
-export default function DiabetesPreventionProgramPage(): ReactNode {
+import DiabetesPreventionDashboard from "@/components/AdminDashboard/DiabetesPreventionDashboard";
+import { getDiabetesPreventionProgramEnrollments } from "@/server/api/program-enrollments/queries";
+
+export default async function DiabetesPrevention(): Promise<ReactNode> {
+  const [diabetesPreventionProgramEnrollments, error] =
+    await getDiabetesPreventionProgramEnrollments();
+
+  if (error !== null) {
+    return (
+      <Box
+        sx={{
+          height: "100vh",
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+        }}
+      >
+        <Typography>There was an error fetching Diabetes Prevention</Typography>
+      </Box>
+    );
+  }
+
   return (
     <Box
       sx={{
-        height: "100vh",
         display: "flex",
+        flexDirection: "column",
         justifyContent: "center",
         alignItems: "center",
+        marginTop: "100px",
+        padding: 4,
       }}
     >
-      <Typography>Diabetes Prevention Program</Typography>
+      <DiabetesPreventionDashboard
+        diabetesPreventionProgramEnrollments={
+          diabetesPreventionProgramEnrollments
+        }
+      />
     </Box>
   );
 }

--- a/src/app/dashboard/admin/programs/healthy-habits/page.tsx
+++ b/src/app/dashboard/admin/programs/healthy-habits/page.tsx
@@ -18,7 +18,7 @@ export default async function HealthyHabits(): Promise<ReactNode> {
           alignItems: "center",
         }}
       >
-        <Typography>There was an error fetching Health Habits</Typography>
+        <Typography>There was an error fetching Healthy Habits</Typography>
       </Box>
     );
   }

--- a/src/components/AdminDashboard/DiabetesPreventionDashboard/DiabetesPreventionClientsDashboard.tsx
+++ b/src/components/AdminDashboard/DiabetesPreventionDashboard/DiabetesPreventionClientsDashboard.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import Alarm from "@mui/icons-material/Alarm";
+import Check from "@mui/icons-material/Check";
+import Close from "@mui/icons-material/Close";
+import QuestionMarkIcon from "@mui/icons-material/QuestionMark";
+import Warning from "@mui/icons-material/Warning";
+import { Box, Tooltip } from "@mui/material";
+import { GridColDef } from "@mui/x-data-grid";
+import { ReactNode } from "react";
+
+import {
+  ClientUser,
+  HealthyHabitsTrackingForm,
+  ProgramEnrollment,
+  User,
+} from "@/types";
+import dayjsUtil from "@/utils/dayjsUtil";
+import getClosestPastSunday from "@/utils/getClosestPastSunday";
+
+import ProgramClientsDashboard, {
+  ProgramClientsDashboardRow,
+} from "../ProgramDashboard/ProgramClientsDashboard";
+import DiabetesPreventionHistoryModal from "./DiabetesPreventionHistoryModal";
+
+type ActivityStatus =
+  | "complete"
+  | "waiting"
+  | "inactiveFor4Weeks"
+  | "inactiveFor8Weeks"
+  | "noTrackingForms";
+
+type DiabetesPreventionRow = ProgramClientsDashboardRow & {
+  trackingForms: HealthyHabitsTrackingForm[];
+  activityStatus: ActivityStatus;
+  user: User;
+};
+
+type DiabetesPreventionClientsDashboardProps = {
+  diabetesPreventionProgramEnrollments: ProgramEnrollment[];
+};
+
+function getStatusIcon(status: ActivityStatus): ReactNode {
+  switch (status) {
+    case "complete":
+      return (
+        <Tooltip title="Completed">
+          <Check color="success" />
+        </Tooltip>
+      );
+    case "waiting":
+      return (
+        <Tooltip title="Not submitted this week">
+          <Alarm color="primary" />
+        </Tooltip>
+      );
+    case "inactiveFor4Weeks":
+      return (
+        <Tooltip title="Inactive for 4 Weeks">
+          <Warning color="warning" />
+        </Tooltip>
+      );
+    case "inactiveFor8Weeks":
+      return (
+        <Tooltip title="Inactive for 8 Weeks">
+          <Close color="error" />
+        </Tooltip>
+      );
+    case "noTrackingForms":
+      return (
+        <Tooltip title="No tracking forms">
+          <QuestionMarkIcon color="primary" />
+        </Tooltip>
+      );
+  }
+}
+
+const createRow = (
+  programEnrollment: ProgramEnrollment,
+): DiabetesPreventionRow => {
+  const user = programEnrollment.user as ClientUser;
+
+  let status: ActivityStatus = "noTrackingForms";
+
+  if (user.healthyHabitsTrackingForms.length > 0) {
+    const latestFormSubmission = user.healthyHabitsTrackingForms[0];
+    const latestFormSubmissionWeek = dayjsUtil(
+      latestFormSubmission.weekOfSubmission,
+    );
+    const lastSunday = getClosestPastSunday();
+    const lastSundayDayJs = dayjsUtil(lastSunday);
+
+    if (latestFormSubmissionWeek.isSame(lastSunday, "day")) {
+      status = "complete";
+    } else if (lastSundayDayJs.diff(latestFormSubmissionWeek, "week") >= 8) {
+      status = "inactiveFor8Weeks";
+    } else if (lastSundayDayJs.diff(latestFormSubmissionWeek, "week") >= 4) {
+      status = "inactiveFor4Weeks";
+    } else if (latestFormSubmissionWeek.isBefore(lastSunday, "day")) {
+      status = "waiting";
+    }
+  }
+
+  return {
+    id: programEnrollment._id,
+    firstName: user.firstName,
+    lastName: user.lastName,
+    phoneNumber: user.phoneNumber,
+    email: user.email,
+    trackingForms: user.healthyHabitsTrackingForms,
+    activityStatus: status,
+    user,
+  };
+};
+
+export default function DiabetesPreventionClientsDashboard({
+  diabetesPreventionProgramEnrollments,
+}: DiabetesPreventionClientsDashboardProps): ReactNode {
+  const rows = diabetesPreventionProgramEnrollments.map(createRow);
+
+  const additionalColumns: GridColDef[] = [
+    {
+      field: "history",
+      headerName: "View history",
+      sortable: false,
+      align: "center",
+      flex: 1,
+      minWidth: 100,
+      renderCell: (params): ReactNode => {
+        return (
+          <DiabetesPreventionHistoryModal
+            initialForms={params.row.trackingForms}
+            user={params.row.user}
+          />
+        );
+      },
+    },
+    {
+      field: "status",
+      headerName: "Status",
+      sortable: false,
+      flex: 1,
+      minWidth: 250,
+      renderCell: (params): ReactNode => {
+        const status = params.row.activityStatus;
+
+        return (
+          <>
+            <Box
+              sx={{
+                display: "flex",
+                justifyContent: "space-around",
+                alignItems: "center",
+                height: "100%",
+              }}
+            >
+              {getStatusIcon(status)}
+            </Box>
+          </>
+        );
+      },
+    },
+  ];
+
+  return (
+    <ProgramClientsDashboard
+      programName="Diabetes Prevention"
+      rows={rows}
+      additionalColumns={additionalColumns}
+    />
+  );
+}

--- a/src/components/AdminDashboard/DiabetesPreventionDashboard/DiabetesPreventionHistoryModal.tsx
+++ b/src/components/AdminDashboard/DiabetesPreventionDashboard/DiabetesPreventionHistoryModal.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import InfoIcon from "@mui/icons-material/Info";
+import { Box, Button, Fade, Modal, Typography } from "@mui/material";
+import { ReactNode, useState } from "react";
+
+import HealthyHabitsHistory from "@/components/ClientDashboard/HealthyHabits/HealthyHabitsHistory";
+import { ClientUser, HealthyHabitsTrackingForm, User } from "@/types";
+
+type DiabetesPreventionHistoryModalProps = {
+  initialForms: HealthyHabitsTrackingForm[];
+  user: User;
+};
+
+const style = {
+  position: "absolute",
+  top: "50%",
+  left: "50%",
+  transform: "translate(-50%, -50%)",
+  width: "min(90vw, 900px)",
+  maxHeight: "80vh",
+  overflowY: "auto",
+  bgcolor: "background.paper",
+  boxShadow: 2,
+  p: 4,
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  gap: 2,
+};
+
+export default function DiabetesPreventionHistoryModal({
+  initialForms,
+  user,
+}: DiabetesPreventionHistoryModalProps): ReactNode {
+  const [open, setOpen] = useState(false);
+  const [trackingForms, setTrackingForms] = useState(initialForms);
+
+  return (
+    <Box width="100%">
+      {/* Info Button */}
+      <Button variant="contained" onClick={() => setOpen(true)}>
+        <InfoIcon />
+      </Button>
+
+      {/* Modal */}
+      <Modal
+        aria-labelledby="transition-modal-title"
+        aria-describedby="transition-modal-description"
+        open={open}
+        onClose={() => setOpen(false)}
+        closeAfterTransition
+      >
+        <Fade in={open}>
+          <Box sx={style}>
+            <Typography variant="h4">
+              Diabetes Prevention Tracking Form History
+            </Typography>
+            <HealthyHabitsHistory
+              trackingForms={trackingForms}
+              setTrackingForms={setTrackingForms}
+              user={user as ClientUser}
+            />
+            <Button
+              variant="outlined"
+              onClick={() => setOpen(false)}
+              sx={{ width: "50%" }}
+            >
+              Close
+            </Button>
+          </Box>
+        </Fade>
+      </Modal>
+    </Box>
+  );
+}

--- a/src/components/AdminDashboard/DiabetesPreventionDashboard/DiabetesPreventionMetrics.tsx
+++ b/src/components/AdminDashboard/DiabetesPreventionDashboard/DiabetesPreventionMetrics.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { Box, Typography } from "@mui/material";
+import { ReactNode } from "react";
+
+import { ClientUser, ProgramEnrollment } from "@/types";
+import dayjsUtil from "@/utils/dayjsUtil";
+import getClosestPastSunday from "@/utils/getClosestPastSunday";
+
+type DiabetesPreventionMetricsProps = {
+  diabetesPreventionProgramEnrollments: ProgramEnrollment[];
+};
+
+export default function DiabetesPreventionMetrics({
+  diabetesPreventionProgramEnrollments,
+}: DiabetesPreventionMetricsProps): ReactNode {
+  const totalEnrolled = diabetesPreventionProgramEnrollments.length;
+  const totalActive = diabetesPreventionProgramEnrollments.reduce(
+    (acc, programEnrollment) => {
+      const user = programEnrollment.user as ClientUser;
+      if (user.healthyHabitsTrackingForms.length <= 0) return acc;
+
+      const latestFormSubmission = user.healthyHabitsTrackingForms[0];
+      const latestFormSubmissionWeek = dayjsUtil(
+        latestFormSubmission.weekOfSubmission,
+      );
+      const lastSunday = getClosestPastSunday();
+      const lastSundayDayJs = dayjsUtil(lastSunday);
+
+      if (lastSundayDayJs.diff(latestFormSubmissionWeek, "week") < 4) acc++;
+
+      return acc;
+    },
+    0,
+  );
+  const registrationsInPast3Months =
+    diabetesPreventionProgramEnrollments.reduce((acc, programEnrollment) => {
+      const registrationDate = dayjsUtil(programEnrollment.dateEnrolled);
+      if (registrationDate.diff(dayjsUtil(), "month") > -3) acc++;
+
+      return acc;
+    }, 0);
+
+  return (
+    <Box>
+      <Typography align="center" variant="h4" sx={{ m: 2 }}>
+        Diabetes Prevention Metrics
+      </Typography>
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          gap: 2,
+        }}
+      >
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 1,
+            borderRadius: 2,
+            boxShadow: 3,
+            padding: 4,
+          }}
+        >
+          <Typography>
+            <strong>Total Enrolled:</strong> {totalEnrolled}
+          </Typography>
+          <Typography>
+            <strong>Total Active:</strong> {totalActive}
+          </Typography>
+          <Typography>
+            <strong>Registrations in Past 3 Months:</strong>{" "}
+            {registrationsInPast3Months}
+          </Typography>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/AdminDashboard/DiabetesPreventionDashboard/index.tsx
+++ b/src/components/AdminDashboard/DiabetesPreventionDashboard/index.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { ReactNode } from "react";
+
+import { ProgramEnrollment } from "@/types";
+
+import ProgramDashboard from "../ProgramDashboard";
+import DiabetesPreventionClientsDashboard from "./DiabetesPreventionClientsDashboard";
+import DiabetesPreventionMetrics from "./DiabetesPreventionMetrics";
+
+type DiabetesPreventionDashboardProps = {
+  diabetesPreventionProgramEnrollments: ProgramEnrollment[];
+};
+
+export default function DiabetesPreventionDashboard({
+  diabetesPreventionProgramEnrollments,
+}: DiabetesPreventionDashboardProps): ReactNode {
+  return (
+    <ProgramDashboard
+      defaultTab="clients"
+      tabs={{
+        clients: {
+          title: "Clients",
+          content: (
+            <DiabetesPreventionClientsDashboard
+              diabetesPreventionProgramEnrollments={
+                diabetesPreventionProgramEnrollments
+              }
+            />
+          ),
+        },
+        metrics: {
+          title: "Metrics",
+          content: (
+            <DiabetesPreventionMetrics
+              diabetesPreventionProgramEnrollments={
+                diabetesPreventionProgramEnrollments
+              }
+            />
+          ),
+        },
+      }}
+    />
+  );
+}

--- a/src/components/AdminDashboard/ProgramDashboard/ProgramClientsDashboard.tsx
+++ b/src/components/AdminDashboard/ProgramDashboard/ProgramClientsDashboard.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import Search from "@mui/icons-material/Search";
+import { Box, TextField, Typography } from "@mui/material";
+import { DataGrid, GridColDef } from "@mui/x-data-grid";
+import { ReactNode, useState } from "react";
+
+export type ProgramClientsDashboardRow = {
+  id?: string;
+  firstName: string;
+  lastName: string;
+  phoneNumber: string;
+  email: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+};
+
+type ProgramClientsDashboardProps<RowType extends ProgramClientsDashboardRow> =
+  {
+    programName: string;
+    rows: RowType[];
+    additionalColumns?: GridColDef<RowType>[];
+  };
+
+export default function ProgramClientsDashboard<
+  RowType extends ProgramClientsDashboardRow,
+>({
+  programName,
+  rows,
+  additionalColumns,
+}: ProgramClientsDashboardProps<RowType>): ReactNode {
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const baseColumns: GridColDef<RowType>[] = [
+    {
+      field: "firstName",
+      headerName: "First name",
+      flex: 1,
+      minWidth: 150,
+    },
+    {
+      field: "lastName",
+      headerName: "Last name",
+      flex: 1,
+      minWidth: 150,
+    },
+    {
+      field: "phoneNumber",
+      headerName: "Phone number",
+      flex: 1,
+      minWidth: 125,
+    },
+    {
+      field: "email",
+      headerName: "Email",
+      flex: 2,
+      minWidth: 200,
+    },
+  ];
+
+  const columns = [...baseColumns, ...(additionalColumns || [])];
+
+  const filteredRows = rows.filter(
+    (row) =>
+      row.firstName.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      row.lastName.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      row.phoneNumber.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      row.email.toLowerCase().includes(searchQuery.toLowerCase()),
+  );
+
+  return (
+    <Box>
+      <Typography align="center" variant="h6">
+        {programName} Clients
+      </Typography>
+      <Box display="flex" alignItems="center" sx={{ py: 2 }}>
+        <TextField
+          id="search-bar"
+          className="text"
+          onChange={(e) => {
+            setSearchQuery(e.target.value);
+          }}
+          placeholder="Search..."
+          size="small"
+        />
+        <Search sx={{ fontSize: 28, m: 1 }} color="primary" />
+      </Box>
+      <DataGrid
+        rows={filteredRows}
+        columns={columns}
+        disableRowSelectionOnClick
+        initialState={{
+          pagination: {
+            paginationModel: {
+              pageSize: 5,
+            },
+          },
+        }}
+        sx={{ height: "300px" }}
+      />
+    </Box>
+  );
+}

--- a/src/components/AdminDashboard/ProgramDashboard/index.tsx
+++ b/src/components/AdminDashboard/ProgramDashboard/index.tsx
@@ -1,0 +1,42 @@
+import { Box, Tab, Tabs } from "@mui/material";
+import { ReactNode, useState } from "react";
+
+type ProgramDashboardProps = {
+  // Tabs config
+  defaultTab: string;
+  tabs: Record<
+    string,
+    {
+      title: string;
+      content: ReactNode;
+    }
+  >;
+};
+
+export default function ProgramDashboard({
+  defaultTab,
+  tabs,
+}: ProgramDashboardProps): ReactNode {
+  const [selectedTab, setSelectedTab] = useState(defaultTab);
+
+  return (
+    <>
+      <Box sx={{ display: "flex", flexDirection: "column", width: "100%" }}>
+        <Box sx={{ alignSelf: "flex-start" }}>
+          <Tabs
+            value={selectedTab}
+            onChange={(_, newValue) => setSelectedTab(newValue)}
+            indicatorColor="primary"
+            textColor="primary"
+          >
+            {Object.keys(tabs).map((key) => (
+              <Tab key={key} value={key} label={tabs[key].title} />
+            ))}
+          </Tabs>
+        </Box>
+
+        <Box sx={{ flexGrow: 1 }}>{tabs[selectedTab].content}</Box>
+      </Box>
+    </>
+  );
+}

--- a/src/server/api/program-enrollments/queries.ts
+++ b/src/server/api/program-enrollments/queries.ts
@@ -131,3 +131,32 @@ export async function getRigsWithoutCigsProgramEnrollments(): Promise<
     return [null, handleMongooseError(error)];
   }
 }
+
+export async function getDiabetesPreventionProgramEnrollments(): Promise<
+  ApiResponse<ProgramEnrollment[]>
+> {
+  await dbConnect();
+  try {
+    const diabetesPreventionEnrollments = await ProgramEnrollmentModel.find({
+      status: "accepted",
+      program: "Diabetes Prevention",
+    })
+      .populate({
+        path: "user",
+        populate: [
+          {
+            // Rename in the future
+            path: "healthyHabitsTrackingForms",
+            options: { sort: { submittedDate: -1 } },
+          },
+        ],
+      })
+      .lean<ProgramEnrollment[]>()
+      .exec();
+
+    return [serializeMongooseObject(diabetesPreventionEnrollments), null];
+  } catch (error) {
+    console.error(error);
+    return [null, handleMongooseError(error)];
+  }
+}


### PR DESCRIPTION
# Description
Implemented two abstractions `ProgramDashboard` and `ProgramClientsDashboard`. Used both these abstractions to implement the admin dashboard for Diabetes Prevention.

Since HH and DP are the exact same, maybe in the future we can merge them into one set of components, and just have a selector that changes the titles, like: `<HHDPDashboard hhdpProgramEnrollments={xxx} program="healthy-habits" />` would change all titles to be "Healthy Habits xxx" and `<HHDPDashboard hhdpProgramEnrollments={xxx} program="diabetes-prevention" />` would change them to "Diabetes Prevention xxx".

There is one `any` type, in `ProgramClientsDashboard` since its hard to determine what exactly will be sent into a row. The `ReactNode`, if a column uses one, is actually created when we define the columns with `GridColDef[]`. When we define the rows, the types are for the data we are going to use to send to the `DataTable`, so it can vary.

## Relevant Issues
#158 