### PR TITLE
feat: Add client comments in managment dashboard

### DIFF
--- a/src/components/AdminDashboard/ClientManagementDashboard/ClientProgramManagementForm/index.tsx
+++ b/src/components/AdminDashboard/ClientManagementDashboard/ClientProgramManagementForm/index.tsx
@@ -154,8 +154,6 @@ export default function ClientProgramManagementForm({
 
     let error = false;
 
-    let newProgramEnrollments = [...programEnrollments];
-
     for (const dirtyField in dirtyFields) {
       const field = dirtyField as keyof ClientManagementFormValues;
 
@@ -175,25 +173,14 @@ export default function ClientProgramManagementForm({
       );
 
       if (!programEnrollment) {
+        error = true;
         return;
       }
 
-      newProgramEnrollments = newProgramEnrollments.map(
-        (prevProgramEnrollment) => {
-          if (prevProgramEnrollment.program === programEnrollment.program) {
-            const enrollmentStatus = data[field] ? "accepted" : "rejected";
+      const enrollmentStatus = data[field] ? "accepted" : "rejected";
+      programEnrollment.status = enrollmentStatus;
 
-            return {
-              ...prevProgramEnrollment,
-              status: enrollmentStatus,
-            };
-          }
-
-          return prevProgramEnrollment;
-        },
-      );
-
-      if (data[field]) {
+      if (enrollmentStatus === "accepted") {
         const [, approveError] =
           await handleApproveProgramApplication(programEnrollment);
 
@@ -217,7 +204,7 @@ export default function ClientProgramManagementForm({
 
     enqueueSnackbar(snakeBarMessage);
 
-    reset(getClientManagementFormDefaultValues(newProgramEnrollments, client));
+    reset(getClientManagementFormDefaultValues(programEnrollments, client));
   };
 
   const showHealthyHabitsButton = !isPending(

--- a/src/components/AdminDashboard/ClientManagementDashboard/index.tsx
+++ b/src/components/AdminDashboard/ClientManagementDashboard/index.tsx
@@ -74,8 +74,8 @@ export default function ClientManagementDashboard({
       minWidth: 350,
       flex: 1,
       renderCell: (params): ReactNode => {
-        const user = params.row.client;
-        const fullName = user.firstName + " " + user.lastName;
+        const client = params.row.client;
+        const fullName = client.firstName + " " + client.lastName;
         return (
           <>
             <Box
@@ -87,10 +87,11 @@ export default function ClientManagementDashboard({
               }}
             >
               <PendingApplicationInfoModal
-                enrollmentForm={user.enrollmentForm}
+                enrollmentForm={client.enrollmentForm}
               />
               <ClientProgramManagementForm
                 programEnrollments={params.row.programEnrollments}
+                client={client}
                 fullName={fullName}
               />
             </Box>

--- a/src/server/api/enrollment-forms/public-mutations.ts
+++ b/src/server/api/enrollment-forms/public-mutations.ts
@@ -46,6 +46,7 @@ export async function handleEnrollmentFormSubmission(
     programEnrollments: [],
     healthyHabitsTrackingForms: [],
     fagerstromTests: [],
+    comments: "",
   };
 
   // create user

--- a/src/server/api/users/private-mutations.ts
+++ b/src/server/api/users/private-mutations.ts
@@ -82,6 +82,7 @@ export async function createClientUser(
 
     return [newUser, null];
   } catch (error) {
+    console.error(error);
     return [null, handleMongooseError(error)];
   }
 }

--- a/src/server/api/users/public-mutations.ts
+++ b/src/server/api/users/public-mutations.ts
@@ -2,7 +2,7 @@
 import bcrypt from "bcrypt";
 
 import dbConnect from "@/server/dbConnect";
-import { ApiResponse } from "@/types";
+import { ApiResponse, ClientUser } from "@/types";
 import authenticateServerFunction from "@/utils/authenticateServerFunction";
 import apiErrors from "@/utils/constants/apiErrors";
 
@@ -96,6 +96,24 @@ export async function verifyEmailWithToken(
   await updateUser(user);
 
   await deleteEmailVerificationToken(token);
+
+  return [null, null];
+}
+
+export async function handleClientUpdate(
+  client: ClientUser,
+): Promise<ApiResponse<null>> {
+  const [, authError] = await authenticateServerFunction("admin");
+
+  if (authError !== null) {
+    return [null, authError];
+  }
+
+  const [, updateError] = await updateUser(client);
+
+  if (updateError !== null) {
+    return [null, updateError];
+  }
 
   return [null, null];
 }

--- a/src/server/models/User.ts
+++ b/src/server/models/User.ts
@@ -58,6 +58,9 @@ const UserSchema = new Schema<User>(
         ref: "FagerstromTest",
       },
     ],
+    comments: {
+      type: String,
+    },
   },
   { versionKey: false },
 );

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -31,6 +31,7 @@ export type ClientUser = {
   programEnrollments: ProgramEnrollment[];
   healthyHabitsTrackingForms: HealthyHabitsTrackingForm[];
   fagerstromTests: FagerstromTest[];
+  comments: string;
 };
 
 export type User = AdminUser | ClientUser;


### PR DESCRIPTION
# Description
Add client comment field in admin dashboard

## Relevant Issues
#153 

## How to Test
1) Submit an enrollment form
2) Verify comment field appears in MongoDB compass

1) Login is as an admin
2) Navigate to the client management dashboard
3) Add a comment on a client comment and save
4) Click on form and verify updates
5) Verify comment in MongoDB compass
